### PR TITLE
fix: wrap all related blocks with enabled configuration

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -344,8 +344,10 @@
                     <ul class="links-list">
                         <li><a href="/a-propos">L'équipe DevLille</a></li>
                         <li><a href="mailto:contact@devlille.fr">Contactez-nous</a></li>
+                        {% if collections.config.enabled.sponsoring %}
                         <li><a href="{{ collections.config.partershipUrl }}">
                             Devenez partenaire</a></li>
+                        {%- endif -%}
                         <li><a href="/code-conduite">Code de conduite</a></li>
                         <li><a href="/promo">Ressources graphiques</a></li>
                         {% if collections.config.enabled.welovedevs  %}

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-﻿---
+---
 layout: layout.html
 currSection: index
 ogUrl: https://devlille.fr/
@@ -20,13 +20,13 @@ ogImage: https://devlille.fr/img/logo-full.svg
     <p>Notre ambition reste intacte : vous proposer deux journées de conférences tech enrichies d'une dimension
       <strong class="stressed">humaine</strong> et <strong class="stressed">environnementale</strong>, en harmonie avec les enjeux du monde actuel.
     </p>
+    {% if collections.config.enabled.billetweb %}
     <p class="register">
-      <a 
-        rel="noreferrer noopener" 
-        target="_blank" 
+      <a rel="noreferrer noopener" target="_blank"
         href="{{ collections.config.billetwebUrl }}{{collections.config.edition}}">
         Prenez votre place!</a>
     </p>
+    {%- endif -%}
   </div>
 
   <div class="cfp">


### PR DESCRIPTION
- Sponsoring presentation is still accessible using the footer link
- The ticket link still visible on small screen