### PR TITLE
fix: resolve TypeScript error on marked() return type

### DIFF
--- a/src/utils/getTalksByDate.ts
+++ b/src/utils/getTalksByDate.ts
@@ -121,7 +121,7 @@ const getTalks = async () => {
           id: schedule.id,
           type: session.type,
           title: session.title ?? "Pause",
-          abstract: marked(rawText)?.replaceAll("h2", "p"),
+          abstract: marked.parse(rawText, { async: false }).replaceAll("h2", "p"),
           language: session.language ?? "fr",
           level: session.level,
           room: schedule.room,


### PR DESCRIPTION
marked() returns string | Promise<string> in v17, so calling
replaceAll directly fails type-checking. Use marked.parse with
async: false to get a synchronous string.

https://claude.ai/code/session_01SZuXbPM2D7HtE6fMhqrYPW